### PR TITLE
Add Sandboxed IFrame widget and command

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "@jupyterlab/application": "^0.15.0",
     "@jupyterlab/apputils": "^0.15.0",
-    "@jupyterlab/docregistry": "^0.15.0",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/widgets": "^1.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@jupyterlab/application": "^0.15.0",
     "@jupyterlab/apputils": "^0.15.0",
     "@phosphor/coreutils": "^1.3.0",
+    "@phosphor/virtualdom": "^1.1.2",
     "@phosphor/widgets": "^1.5.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "jupyterlab_iframe",
+  "name": "jupyterlab_sandbox",
   "version": "0.1.0",
-  "description": "Load webpages as IFrames embedded in panels",
+  "description": "Load webpages as sandboxed IFrames embedded in panels",
   "keywords": [
     "extension",
     "jupyter",
     "jupyterlab"
   ],
-  "homepage": "https://github.com/canavandl/jupyterlab_iframe",
+  "homepage": "https://github.com/canavandl/jupyterlab_sandbox",
   "bugs": {
-    "url": "https://github.com/canavandl/jupyterlab_iframe/issues"
+    "url": "https://github.com/canavandl/jupyterlab_sandbox/issues"
   },
   "license": "BSD-3-Clause",
   "author": "Luke Canavan",
@@ -21,7 +21,7 @@
   "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/canavandl/jupyterlab_iframe.git"
+    "url": "https://github.com/canavandl/jupyterlab_sandbox.git"
   },
   "scripts": {
     "build": "tsc",
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.6.1",
-    "typescript": "~2.6.0"
+    "typescript": "~2.6.2"
   },
   "jupyterlab": {
     "extension": true

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,45 +4,43 @@ import {
 } from '@jupyterlab/application'
 
 import {
-  ICommandPalette
+  ICommandPalette,
+  IFrame
 } from '@jupyterlab/apputils'
 
 import {
-  DocumentRegistry
-} from '@jupyterlab/docregistry'
-
-import {
-  JSONObject,
-  PromiseDelegate
+  JSONObject
 } from '@phosphor/coreutils'
 
 import {
+  PanelLayout,
   Widget
 } from '@phosphor/widgets'
+import { Message } from '@phosphor/messaging';
 
 // import '../style/index.css';
 
-class IFrame extends Widget implements DocumentRegistry.IReadyWidget {
-  private _element: HTMLIFrameElement
-  private _ready = new PromiseDelegate<void>();
+class PanelIFrame extends Widget {
+  readonly url: string
 
-  constructor(args: JSONObject) {
+  constructor(url: string) {
     super()
+    this.url = url
 
-    this._element = document.createElement("iframe")
+    let layout = this.layout = new PanelLayout()
+    let iframe = new IFrame()
+    iframe.url = url
 
-    this._render()
+    layout.addWidget(iframe)
   }
 
-  get ready(): Promise<void> {
-    return this._ready.promise;
+  protected onActivateRequest(msg: Message): void {
+    this.node.tabIndex = -1;
+    this.node.focus();
   }
 
-  private _render(): void {
-    this._element.src = 'https://www.google.com'
-
-    this.node.appendChild(this._element)
-
+  protected onCloseRequest(msg: Message) {
+    this.dispose()
   }
 }
 
@@ -67,7 +65,12 @@ const extension: JupyterLabPlugin<void> = {
     commands.addCommand(CommandIDs.create, {
       label: 'Load IFrame',
       execute: (args: JSONObject) => {
-        let frame = new IFrame(args)
+
+        let frame = new PanelIFrame('https://jupyterlab.readthedocs.io/en/stable/')
+        frame.title.label = 'my title label'
+        frame.title.closable = true
+        frame.id = 'my-custom-id-and-stuff'
+
         app.shell.addToMainArea(frame)
       }
     })

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,10 +14,6 @@ import {
   Widget
 } from '@phosphor/widgets';
 
-// import {
-//   ElementAttrNames,
-// } from '@phosphor/virtualdom';
-
 
 // import '../style/index.css';
 
@@ -27,6 +23,10 @@ class Sandbox extends IFrame implements Sandbox.IModel {
 
   constructor() {
     super()
+  }
+
+  get iframeNode() {
+    return this.node.querySelector('iframe')
   }
 
   get sandboxAttr() {
@@ -39,8 +39,7 @@ class Sandbox extends IFrame implements Sandbox.IModel {
 
   set sandBox(attrs: Sandbox.TSandboxOptions) {
     this._sandBox = attrs
-    let iframe = this.node.querySelector('iframe')
-    iframe.setAttribute('sandbox', this.sandboxAttr)
+    this.iframeNode.setAttribute('sandbox', this.sandboxAttr)
   }
 }
 
@@ -58,8 +57,7 @@ namespace Sandbox {
 
 
   /** A type that can enable sandbox permissions */
-  export type TSandboxOptions = {[P in TSandboxPerm]?: boolean; };
-
+  export type TSandboxOptions = {[P in TSandboxPerm]?: boolean};
 
   /** Generally useful subset of permissions that can run things like JupyterLab and Bokeh */
   export const DEFAULT_SANDBOX: TSandboxOptions = {
@@ -69,15 +67,14 @@ namespace Sandbox {
     'allow-scripts': true,
   };
 
+  // todo implement error handling?
   // export type TSandBoxProblem = 'no-src' | 'insecure-origin' | 'protocol-mismatch';
 
-  /** Base frame model */
+  /** Base sandbox model */
   export interface IModel {
-    // extraAttrs: {[P in ElementAttrNames]?: string};
     // problem: TSandBoxProblem;
     sandBox: TSandboxOptions;
     sandboxAttr: string;
-    // shouldDraw: boolean;
   }
 }
 
@@ -117,7 +114,7 @@ const extension: JupyterLabPlugin<void> = {
   requires: [ICommandPalette],
   activate: (app: JupyterLab, palette: ICommandPalette) => {
     let counter = 0;
-    const namespace = 'sandbox-widget';
+    const namespace = 'sandbox-ext';
 
     app.commands.addCommand(CommandIDs.create, {
       label: 'Web Page',

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,19 +18,22 @@ import {
 } from '@phosphor/coreutils';
 
 import {
-  Widget
+  Widget,
+  Panel
 } from '@phosphor/widgets';
-
 
 
 // import '../style/index.css';
 
 
-export class Sandbox extends IFrame {
+export class Sandbox extends Panel {
   private _sandBox: SandboxNS.TSandboxOptions
+  private _frame: IFrame
 
   constructor() {
     super()
+    this._frame = new IFrame()
+    this.addWidget(this._frame)
   }
 
   get iframeNode() {
@@ -49,6 +52,14 @@ export class Sandbox extends IFrame {
     this._sandBox = attrs
     this.iframeNode.setAttribute('sandbox', this.sandboxAttr)
   }
+
+  get url() {
+    return this._frame.url
+  }
+
+  set url(url: string) {
+    this._frame.url = url
+  }
 }
 
 
@@ -58,6 +69,8 @@ class SandboxModal extends Widget {
     let label = document.createElement("label")
     label.textContent = 'Input a valid url'
     let input = document.createElement("input")
+    // perhaps should just match window.location.protocol?
+    input.placeholder = "protocol:host"
     body.appendChild(label)
     body.appendChild(input)
     super({ node: body })

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,6 @@ import {
 
 // import '../style/index.css';
 
-
 class IFrame extends Widget implements DocumentRegistry.IReadyWidget {
   private _element: HTMLIFrameElement
   private _ready = new PromiseDelegate<void>();


### PR DESCRIPTION
Add Sandboxed IFrame widget and command
* [x] Add ILayoutRestorer functionality
* [ ] Add model css to increase visible input width (will have to reimplement ``showDialog`` to access className ?)
* [ ] Write better copy for modal
* [ ] Make panel title be "Web Page: [url]" or just "[url]"

Questions?
* [ ] Why isn't the Sandbox panel added as the top tab and "selected" via CSS ?!?
* [ ] Error handling for bad urls or security errors (ie CORS)? Throw error in modal?
